### PR TITLE
Specify column index in separate()

### DIFF
--- a/06-walkthrough-1.Rmd
+++ b/06-walkthrough-1.Rmd
@@ -206,7 +206,7 @@ We also can process the course data in order to obtain more information.
 ```{r}
 # split course section into components
 s12_course_data <- s12_course_data %>%
-  separate(col = CourseSectionOrigId,
+  separate(col = 1,
            into = c('subject', 'semester', 'section'),
            sep = '-',
            remove = FALSE)


### PR DESCRIPTION
This is a fix for issue #61 

The only way I could make it work was to use the column index, which isn't very pretty. I tried all manner of `!!`, `{{`, and `enquo()` related things but couldn't get it to work with the column name. I can verify all code works with the column index though. 