### PR TITLE
Add chapter for references

### DIFF
--- a/18-conclusion.Rmd
+++ b/18-conclusion.Rmd
@@ -51,3 +51,5 @@ interest.
 That curiosity, passion, and interest for educational and social (and data
 science in education-related) topics is important to cultivate - perhaps as
 important as the capabilities that this book focused on.
+
+# References

--- a/18-conclusion.Rmd
+++ b/18-conclusion.Rmd
@@ -51,5 +51,3 @@ interest.
 That curiosity, passion, and interest for educational and social (and data
 science in education-related) topics is important to cultivate - perhaps as
 important as the capabilities that this book focused on.
-
-# References

--- a/19-references.R
+++ b/19-references.R
@@ -1,0 +1,1 @@
+# References


### PR DESCRIPTION
per the bookdown book:

> For non-LaTeX output, you can add an empty chapter as the last chapter of your book.

This adds an empty chapter with the level-1 header References, so the references won't be added to the last chapter.