### PR TITLE
add split_bib: no to _output.yml

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -1,4 +1,5 @@
 bookdown::gitbook:
+  split_bib: no
   includes:
     in_header: google_analytics.html
   css: css/style.css


### PR DESCRIPTION
Using the instructions from here: https://github.com/rstudio/bookdown/issues/186

This is intended to address #183 (note from @ivelasq). 