### PR TITLE
corrected citation from `dierksen2015` to `@dirksen2015`

### DIFF
--- a/16-teaching-data-science.Rmd
+++ b/16-teaching-data-science.Rmd
@@ -144,7 +144,7 @@ Educators and educational researchers often talk about metacognition, or thinkin
 
 While teachers are responsible for designing learning opportunities, learners also play an important role - in their own learning! Learning strategies, according to the authors of *HPL2*, matter, including those that help students to retrieve information and summarize and explain what they have learned (for themselves and others). There are many specific strategies documented in [chapter four](https://www.nap.edu/read/24783/chapter/6#72) of *HPL2*. What is important for teachers of data science to know is less the specific strategies, and more the commitment to teaching learners how to learn. 
 
-In addition to strategies for learners, teaching strategies, such as how content is spaced and sequenced, can also help learners. @dierksen2015's *Design for How People Learn* presents these strategies, based largely about instructional design research, that may be helpful to those teaching data science.
+In addition to strategies for learners, teaching strategies, such as how content is spaced and sequenced, can also help learners. @dirksen2015's *Design for How People Learn* presents these strategies, based largely about instructional design research, that may be helpful to those teaching data science.
 
 ### Educators can help students to learn
 


### PR DESCRIPTION
There are two missing citations (rendered as **???**) in bookdown. The first is in section 16.2.5--_however_ the citation appears correct, so unsure why it is not rendering. In the second, there appears to be a typo. I corrected it (I think 😉) to match the key in the book.bib file. I also flagged this with a new issue.