### PR TITLE
put apalike in quotes

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -5,7 +5,7 @@ site: bookdown::bookdown_site
 output: bookdown::gitbook
 documentclass: book
 bibliography: [book.bib, packages.bib]
-biblio-style: apalike
+biblio-style: "apalike"
 link-citations: yes
 github-repo: data-edu/data-science-in-education
 description: "Bookdown for 'Data Science in Education Using R' by Emily A. Bovee, Ryan A. Estrellado, Jesse Mostipak, Joshua M. Rosenberg, and Isabella C. Velásquez to be published by Routledge in 2020"


### PR DESCRIPTION
This is an attempt to change the bibliography style to "apalike" (per #183). 

I added quotes around `apalike`, so it now is: `"apalike"`. 

However, these two sources make it seem like we may need to do something with a `.csl` file:

- https://github.com/rstudio/bookdown/issues/354 (also noting that `apalike` does not have quotes around it in the example)
- https://stackoverflow.com/questions/50652853/how-to-specify-a-csl-bibliography-style-on-bookdown

If we did what the GitHub issue above did, I think we would add the following argument to `_output.yml`:

- `pandoc_args: [ "--csl", "apa_pl.csl" ]`
- add the `"apa_pl.csl" file to the repo (file available [here](https://github.com/citation-style-language/styles/blob/master/apa.csl))