### PR TITLE
Hide results for file paths

### DIFF
--- a/10-wt-longitudinal-analysis.Rmd
+++ b/10-wt-longitudinal-analysis.Rmd
@@ -123,7 +123,7 @@ Imagine a widget-making machine that works by acting on raw materials it receive
 
 Let's create the raw materials first. Our raw materials will be file paths to each of the CSVs we want to read. Use `list.files` to make a vector of filename paths and name that vector `filenames`. `list.files` returns a vector of file names in the folder specified in the `path` argument. When we set the `full.names` argument to "TRUE", we get a full path of these filenames. This will be useful later when we need the file names and their paths to read our data in. 
 
-```{r get filenames}
+```{r get filenames, results='hide'}
 # Get filenames from the data folder 
 filenames <-
   list.files(path = here::here("data", "longitudinal_data"),


### PR DESCRIPTION
Setting `results` to "hide" on a file chunk that makes the actual file paths show in the bookdown website